### PR TITLE
HSBC use cvv2 response correctly + Payflow BuyerAuthResult XML update + ...

### DIFF
--- a/lib/AktiveMerchant/Billing/Gateways/HsbcSecureEpayments.php
+++ b/lib/AktiveMerchant/Billing/Gateways/HsbcSecureEpayments.php
@@ -397,7 +397,7 @@ XML;
         $options['fraud_review'] = isset($response['return_code']) ? in_array($response['return_code'], $this->FRAUDULENT) : false;
 
         if (isset($response['cvv2_resp'])) {
-            if (in_array($response['cvv2_resp'], $this->HSBC_CVV_RESPONSE_MAPPINGS))
+            if ( array_key_exists($response['cvv2_resp'], $this->HSBC_CVV_RESPONSE_MAPPINGS) )
                 $options['cvv_result'] = $this->HSBC_CVV_RESPONSE_MAPPINGS[$response['cvv2_resp']];
         }
         $options['avs_result'] = $this->avs_code_from($response);

--- a/lib/AktiveMerchant/Billing/Gateways/Payflow.php
+++ b/lib/AktiveMerchant/Billing/Gateways/Payflow.php
@@ -196,8 +196,7 @@ XML;
             $tds = $options['three_d_secure'];
             $xml .= <<<XML
                 <BuyerAuthResult>
-                    <AUTHSTATUS3DS>{$tds['pares_status']}</AUTHSTATUS3DS>
-                    <MPIVENDOR3DS>{$tds['enrolled']}</MPIVENDOR3DS>
+                    <Status>{$tds['pares_status']}</Status>
                     <ECI>{$tds['eci_flag']}</ECI>
                     <CAVV>{$tds['cavv']}</CAVV>
                     <XID>{$tds['xid']}</XID>

--- a/lib/AktiveMerchant/Billing/Gateways/PaypalExpress.php
+++ b/lib/AktiveMerchant/Billing/Gateways/PaypalExpress.php
@@ -126,6 +126,9 @@ class PaypalExpress extends PaypalCommon
             'CANCELURL'            => $options['cancel_return_url']
         );
 
+        if(isset($options['header_image']))
+            $params['HDRIMG'] = $options['header_image'];
+
         $this->post = array_merge(
             $this->post, 
             $params, 


### PR DESCRIPTION
...PaypalExpress allow header image

Hi Andreas,

Here are a few changes from the php 5.2 version of AM that were never ported over

Cheers
