### PR TITLE
CentinelPaypal implementation

### DIFF
--- a/lib/AktiveMerchant/Billing/Gateways/Centinel.php
+++ b/lib/AktiveMerchant/Billing/Gateways/Centinel.php
@@ -23,13 +23,11 @@ class Centinel extends Gateway
     const LIVE_URL = 'https://centinel.cardinalcommerce.com/maps/txns.asp';
 
     # The countries the gateway supports merchants from as 2 digit ISO country codes
-
     public static $supported_countries = array('US', 'GR');
 
-    # The card types supported by the payment gateway
-    public static $homepage_url = 'http://www.cardinalcommerce.com';
-
     # The homepage URL of the gateway
+    public static $homepage_url = 'http://www.cardinalcommerce.com';
+    
     public static $display_name = 'Centinel 3D Secure';
     public static $money_format = 'cents';
     public static $default_currency = 'EUR';
@@ -144,7 +142,7 @@ XML;
 
     private function commit($action, $money, $parameters)
     {
-        $url = $this->is_test() ? self::TEST_URL : self::LIVE_URL;
+        $url = $this->is_test() ? static::TEST_URL : static::LIVE_URL;
 
         $data = $this->ssl_post($url, $this->post_data($action, $parameters, array('timeout' => '10')));
 

--- a/lib/AktiveMerchant/Billing/Gateways/CentinelPaypal.php
+++ b/lib/AktiveMerchant/Billing/Gateways/CentinelPaypal.php
@@ -1,0 +1,19 @@
+<?php
+
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+namespace AktiveMerchant\Billing\Gateways;
+
+use namespace AktiveMerchant\Billing\Gateways\Centinel;
+
+/**
+ * Extension of Centinel gateway that connects to the
+ * paypal subdomain of Cardinal Commmerce in live env
+ *
+ * @package Aktive-Merchant
+ * @license http://www.opensource.org/licenses/mit-license.php
+ */
+class CentinelPaypal extends Centinel 
+{
+    const LIVE_URL = 'https://paypal.cardinalcommerce.com/maps/txns.asp';
+}


### PR DESCRIPTION
"Extension of Centinel gateway that connects to the paypal subdomain of Cardinal Commmerce in live env"

Changes made as requested:
- use static:: to overwrite LIVE_URL
- remove ?>
- tab size 4 + tabs converted to spaces
