### PR TITLE
Fix "unknown SSL protocol error in connection to centineltest.cardinalcommerce.com:443"

### DIFF
--- a/lib/AktiveMerchant/Http/Adapter/cUrl.php
+++ b/lib/AktiveMerchant/Http/Adapter/cUrl.php
@@ -198,7 +198,8 @@ class cUrl implements AdapterInterface
             //close connection when it has finished, not pooled for reuse
             CURLOPT_FORBID_REUSE    => 1,
             // Do not use cached connection
-            CURLOPT_FRESH_CONNECT   => 1
+            CURLOPT_FRESH_CONNECT   => 1,
+            CURLOPT_SSLVERSION      => 3
         );
 
         $config = $this->map_config($request->getConfig());


### PR DESCRIPTION
CURLOPT_SSLVERSION is no longer explicitly set to 3. In some environments PHP defaults to 2 which results in an unknown SSL protocol error when using the 3D-Secure gateway in testing.

This PR fixes this issue by setting SSLVERSION to 3.
