### PR TITLE
Fix paypal express authorisation

### DIFF
--- a/lib/AktiveMerchant/Billing/Gateways/PaypalExpress.php
+++ b/lib/AktiveMerchant/Billing/Gateways/PaypalExpress.php
@@ -100,6 +100,7 @@ class PaypalExpress extends PaypalCommon
             'AMT'               => $this->amount($money),
             'AUTHORIZATIONID'   => $authorization,
             'COMPLETETYPE'      => $options['complete_type'],
+            "CURRENCYCODE"      => $this->options["currency"]
         );
 
         $this->post = array_merge(


### PR DESCRIPTION
Paypal express commit and authorisation doesn't work at the moment. This fixes that.

It also fixes non-default currency transactions
