### PR TITLE
BC break: fix accepting amount format for Stripe

### DIFF
--- a/lib/AktiveMerchant/Billing/Gateways/Stripe.php
+++ b/lib/AktiveMerchant/Billing/Gateways/Stripe.php
@@ -136,7 +136,7 @@ class Stripe extends Gateway implements
      */
     public function capture($money, $authorization, $options = array())
     {
-        $this->post = array('amount' => $this->amount($money / 100));
+        $this->post = array('amount' => $this->amount($money));
 
         $action = sprintf(self::CAPTURE, $authorization);
 
@@ -159,7 +159,7 @@ class Stripe extends Gateway implements
      */
     public function credit($money, $identification, $options = array())
     {
-        $this->post = array('amount' => $this->amount($money / 100));
+        $this->post = array('amount' => $this->amount($money));
 
         $action = sprintf(self::REFUND, $identification);
 
@@ -261,7 +261,7 @@ class Stripe extends Gateway implements
      */
     private function addInvoice($money, $options)
     {
-        $this->post['amount'] = $this->amount($money / 100);
+        $this->post['amount'] = $this->amount($money);
         $this->post['currency'] = self::$default_currency;
         $this->post['description'] = $options['description'];
     }

--- a/tests/AktiveMerchant/Billing/Gateways/StripeTest.php
+++ b/tests/AktiveMerchant/Billing/Gateways/StripeTest.php
@@ -20,7 +20,7 @@ class StripeTest extends TestCase
         $options['currency'] = 'EUR';
 
         $this->gateway = new Stripe($options);
-        $this->amount = 1000;
+        $this->amount = 10;
         $this->creditcard = new CreditCard(
             array(
                 "first_name" => "John",
@@ -46,7 +46,7 @@ class StripeTest extends TestCase
         );
     }
 
-    public function testSuccessPurchase()
+    public function testSuccessfulPurchase()
     {
         $this->mock_request($this->successPurchaseResponse());
         $response = $this->gateway->purchase(
@@ -57,6 +57,9 @@ class StripeTest extends TestCase
 
         $this->assert_success($response);
         $this->assertNotNull($response->authorization());
+        $this->assertEquals('1000', $response->params()->amount);
+        parse_str($this->request->getBody(), $result);
+        $this->assertEquals('1000', $result['amount']);
     }
 
     public function testFailPurchase()
@@ -68,7 +71,6 @@ class StripeTest extends TestCase
             $this->creditcard,
             $this->options
         );
-
         $this->assert_failure($response);
         $this->assertEquals('Your card was declined.', $response->message());
     }


### PR DESCRIPTION
Stripe gateway expecting amounts in cents, while should be accepts
in base units.